### PR TITLE
fix normalize widget in tsa notebook

### DIFF
--- a/notebooks/sep_analysis_tools/onset_functions.py
+++ b/notebooks/sep_analysis_tools/onset_functions.py
@@ -1676,10 +1676,15 @@ class Event:
                                      style = style
                                      )
 
-        button = widgets.Checkbox(value = False,
-                                  description = "Normalize",
-                                  indent = True
-                                  )
+        # button = widgets.Checkbox(value = False,
+        #                           description = "Normalize",
+        #                           indent = True
+        #                           )
+        button = widgets.RadioButtons(value='original data', 
+                                      description='Intensity:',
+                                      options=['original data', 'normalized'],
+                                      disabled=False
+                                      )
 
         # A box for the path length
         path_label = f"R={radial_distance_value:.2f} AU\nL = {slider.value} AU"


### PR DESCRIPTION
Replace `Checkbox` widget that is not working on the server with a `RadioButton` widget. As the functionality only monitors the _change_ of the widget, and not uses the actual _values_ of it, the simple replacement of the widget is enough (hopefully 😬).